### PR TITLE
Fix /users/<built-in function id> endpoint to handle users without email

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,6 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    email_domain = user.email.split("@")[1] if user.email else None
 
     return {"id": user.id, "name": user.name, "email_domain": email_domain}

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -12,3 +12,13 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_without_email(db, client):
+    # Create a user without an email
+    user = User(name="Bob")
+    db.add(user)
+    db.commit()
+
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id, "name": user.name, "email_domain": None}


### PR DESCRIPTION
This PR fixes the /users/<built-in function id> endpoint to gracefully handle cases where the user doesn't have an email address. The endpoint now returns the email_domain as None in the response when the user's email is not available.