### PR TITLE
Fix 500 error in /users/{id} endpoint when user has no email

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,9 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    response_data = {"id": user.id, "name": user.name}
+    if user.email:
+        email_domain = user.email.split("@")[1]
+        response_data["email_domain"] = email_domain
 
-    return {"id": user.id, "name": user.name, "email_domain": email_domain}
+    return response_data

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -12,3 +12,16 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_no_email(db, client):
+    # Create test data
+    user = User(name="Bob")
+    db.add(user)
+    db.commit()
+
+    # Check that the user was added to the database
+    assert db.query(User).count() == 1
+
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id, "name": user.name}


### PR DESCRIPTION
Fixes #6

- Handle case when user.email is None in get_user function
- Add test case for user without email
- Update test case for user without email to expect 200 status code and correct response data