### PR TITLE
Fix user endpoint email handling

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,6 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    email_domain = user.email.split("@")[1] if user.email else None
 
     return {"id": user.id, "name": user.name, "email_domain": email_domain}

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -12,3 +12,13 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_without_email(db, client):
+    # Create a user without an email address
+    user = User(name="Bob")
+    db.add(user)
+    db.commit()
+
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id, "name": user.name, "email_domain": None}


### PR DESCRIPTION
## Description
This PR fixes the issue where the `/users/{id}` endpoint was returning a 500 Internal Server Error when the requested user did not have an email address associated with their account.

## Changes
- Updated the `get_user` function in `api/endpoints/users.py` to handle cases where the user does not have an email address
- Modified the test case `test_get_user_without_email` in `tests/test_users_endpoint.py` to expect a 200 OK response with `email_domain` set to `None`

Resolves #123