### PR TITLE
Fix user endpoint to handle users without email addresses

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,8 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    email_domain = None
+    if user.email:
+        email_domain = user.email.split("@")[1]
 
     return {"id": user.id, "name": user.name, "email_domain": email_domain}

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -1,6 +1,6 @@
 from api.models import User
 
-def test_get_user(db, client):
+def test_get_user_with_email(db, client):
     # Create test data
     user = User(name="Alice", email="alice@example.com")
     db.add(user)
@@ -12,3 +12,16 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_without_email(db, client):
+    # Create test data
+    user = User(name="Bob", email=None)
+    db.add(user)
+    db.commit()
+
+    # Check that the user was added to the database
+    assert db.query(User).count() == 1
+
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id, "name": user.name, "email_domain": None}


### PR DESCRIPTION
This PR fixes the issue where the /users/<built-in function id> endpoint returns a 500 error when a user has no email address. It modifies the endpoint to handle cases where the user's email is None, returning null for the email_domain field instead of causing an error. New test cases have been added to cover this scenario.