### PR TITLE
Fix user endpoint to handle users without email addresses

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,8 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    email_domain = None
+    if user.email:
+        email_domain = user.email.split("@")[1]
 
     return {"id": user.id, "name": user.name, "email_domain": email_domain}

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -12,3 +12,13 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_no_email(db, client):
+    # Create test data for a user without an email
+    user_no_email = User(name="Bob")
+    db.add(user_no_email)
+    db.commit()
+
+    response = client.get(f"/users/{user_no_email.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user_no_email.id, "name": user_no_email.name, "email_domain": None}


### PR DESCRIPTION
This PR addresses the issue where the /users/<built-in function id> endpoint returns a 500 error when a user has no email address.