### PR TITLE
Fix DEMO-270: Handle users without email in /users/<built-in function id> endpoint

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,8 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    email_domain = None
+    if user.email:
+        email_domain = user.email.split("@")[1]
 
     return {"id": user.id, "name": user.name, "email_domain": email_domain}

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -1,6 +1,6 @@
 from api.models import User
 
-def test_get_user(db, client):
+def test_get_user_with_email(db, client):
     # Create test data
     user = User(name="Alice", email="alice@example.com")
     db.add(user)
@@ -12,3 +12,16 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_without_email(db, client):
+    # Create test data
+    user = User(name="Bob", email=None)
+    db.add(user)
+    db.commit()
+
+    # Check that the user was added to the database
+    assert db.query(User).count() == 1
+
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id, "name": user.name, "email_domain": None}


### PR DESCRIPTION
This PR addresses the DEMO-270 issue by modifying the /users/<built-in function id> endpoint to handle cases where users don't have an email address. It now returns a 200 OK response with the email_domain field set to null for users without an email address. Changes: 1) Modified api/endpoints/users.py to handle users without email addresses. 2) Added a new test case in tests/test_users_endpoint.py.