### PR TITLE
Fix 500 error in /users/{id} endpoint for users without email

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,8 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    email_domain = None
+    if user.email:
+        email_domain = user.email.split("@")[1]
 
     return {"id": user.id, "name": user.name, "email_domain": email_domain}

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -12,3 +12,16 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_without_email(db, client):
+    # Create test data
+    user = User(name="Bob", email=None)
+    db.add(user)
+    db.commit()
+
+    # Check that the user was added to the database
+    assert db.query(User).count() == 1
+
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id, "name": user.name, "email_domain": None}


### PR DESCRIPTION
This PR addresses the issue DEMO-270 where the /users/{id} endpoint was returning a 500 error for users without an email address.

Changes made:
1. Modified the get_user function in api/endpoints/users.py to handle cases where user.email is None.
2. Added a new test case test_get_user_without_email in tests/test_users_endpoint.py to ensure the endpoint works correctly for users without an email.

The fix ensures that the API gracefully handles users both with and without email addresses, preventing the 500 Internal Server Error.