### PR TITLE
Fix 500 error for users without email in /users/<built-in function id> endpoint

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,8 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    response = {"id": user.id, "name": user.name}
+    if user.email:
+        response["email_domain"] = user.email.split("@")[1]
 
-    return {"id": user.id, "name": user.name, "email_domain": email_domain}
+    return response

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -1,14 +1,21 @@
 from api.models import User
 
-def test_get_user(db, client):
+def test_get_user_with_email(db, client):
     # Create test data
     user = User(name="Alice", email="alice@example.com")
     db.add(user)
     db.commit()
 
-    # Check that the user was added to the database
-    assert db.query(User).count() == 1
-
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_without_email(db, client):
+    # Create test data
+    user = User(name="Bob", email=None)
+    db.add(user)
+    db.commit()
+
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id, "name": user.name}


### PR DESCRIPTION
This PR addresses issue #9 by handling cases where users don't have an email address. It modifies the /users/<built-in function id> endpoint to return a 200 OK response with appropriate user data, regardless of whether the user has an email or not. New test cases have been added to cover both scenarios.