### PR TITLE
Fix DEMO-270: Handle users without email in /users/{id} endpoint

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,8 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    email_domain = None
+    if user.email:
+        email_domain = user.email.split("@")[1]
 
     return {"id": user.id, "name": user.name, "email_domain": email_domain}

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -12,3 +12,16 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_without_email(db, client):
+    # Create test data for a user without an email
+    user_without_email = User(name="Bob", email=None)
+    db.add(user_without_email)
+    db.commit()
+
+    # Check that the user was added to the database
+    assert db.query(User).count() == 1
+
+    response = client.get(f"/users/{user_without_email.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user_without_email.id, "name": user_without_email.name, "email_domain": None}


### PR DESCRIPTION
This PR addresses the DEMO-270 issue where the /users/{id} API endpoint was returning a 500 error when a user had no email address.

Changes made:
1. Modified the get_user function in api/endpoints/users.py to handle cases where the user's email is None.
2. Updated the endpoint to return null for email_domain when there's no email.
3. Added a new test case in tests/test_users_endpoint.py to cover the scenario of a user without an email.

These changes ensure that the API now correctly handles users with and without email addresses, returning appropriate responses in both cases.