### PR TITLE
fix(api): Handle missing user email in /users/{id} endpoint

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,8 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
-
-    return {"id": user.id, "name": user.name, "email_domain": email_domain}
+    if user.email:
+        email_domain = user.email.split("@")[1]
+        return {"id": user.id, "name": user.name, "email_domain": email_domain}
+    else:
+        return {"id": user.id, "name": user.name}

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -12,3 +12,16 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_no_email(db, client):
+    # Create test data
+    user = User(name="Bob")
+    db.add(user)
+    db.commit()
+
+    # Check that the user was added to the database
+    assert db.query(User).count() == 1
+
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id, "name": user.name}


### PR DESCRIPTION
Resolves #9

The `/users/{id}` endpoint was raising a 500 error when the user did not have an email address. This PR fixes the issue by:

- Modifying the `get_user` function in `api/endpoints/users.py` to handle the case when `user.email` is `None`, returning the user details without the `email_domain` field.
- Adding a new test case `test_get_user_no_email` to ensure the fix works and prevent regressions.

All tests are passing after the fix.