### PR TITLE
Fix 500 error when user has no email address

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,8 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    email_domain = None
+    if user.email:
+        email_domain = user.email.split("@")[1]
 
     return {"id": user.id, "name": user.name, "email_domain": email_domain}

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -12,3 +12,16 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_without_email(db, client):
+    # Create test user without email
+    user = User(name="Bob")
+    db.add(user)
+    db.commit()
+
+    # Check that the user was added to the database
+    assert db.query(User).filter(User.name == "Bob").count() == 1
+
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id, "name": user.name, "email_domain": None}


### PR DESCRIPTION
Fixes #9

## Problem
The API endpoint `/users/{id}` was returning a 500 Internal Server Error when a user did not have an email address. This was happening because the code was trying to split a null email value.

## Solution
- Modified the endpoint to check if the user has an email before trying to split it
- Added a test case to verify the behavior when a user has no email address
- The endpoint now returns the email_domain as null when the user has no email

## Testing
Added a specific test case that creates a user without an email and verifies the endpoint returns a 200 OK response with email_domain set to null.