### PR TITLE
Fix 500 error when user has no email address

### DIFF
--- a/api/endpoints/users.py
+++ b/api/endpoints/users.py
@@ -23,6 +23,10 @@ async def get_user(user_id: int, db: Session = Depends(get_db)):
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    email_domain = user.email.split("@")[1]
+    response = {"id": user.id, "name": user.name}
+    
+    if user.email:
+        email_domain = user.email.split("@")[1]
+        response["email_domain"] = email_domain
 
-    return {"id": user.id, "name": user.name, "email_domain": email_domain}
+    return response

--- a/tests/test_users_endpoint.py
+++ b/tests/test_users_endpoint.py
@@ -12,3 +12,15 @@ def test_get_user(db, client):
     response = client.get(f"/users/{user.id}")
     assert response.status_code == 200
     assert response.json() == {"id": user.id, "name": user.name, "email_domain": "example.com"}
+
+def test_get_user_without_email(db, client):
+    # Create test data for a user without an email
+    user = User(name="Bob", email=None)
+    db.add(user)
+    db.commit()
+
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id, "name": user.name}
+    # Verify that email_domain is not in the response
+    assert "email_domain" not in response.json()


### PR DESCRIPTION
Fixes #9

## Problem
The API endpoint  was returning a 500 Internal Server Error when a user had no email address. This was happening because the code was trying to split a null email value.

## Solution
- Modified the endpoint to handle cases where a user has no email address
- Added a conditional check to only include the email_domain in the response when an email exists
- Added a test case to verify the fix works correctly for users without email addresses

## Testing
Added a new test case that verifies the endpoint returns a 200 OK response for users without an email address, with the email_domain field omitted from the response.